### PR TITLE
fix: remove Dockerfile inclusion for now

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -218,7 +218,7 @@ func (d Docker) Publish(ctx context.Context) error {
 			return err
 		}
 
-		args = []string{"docker", "scan", "--accept-license", "-f", d.cfg.Dockerfile, "--severity", "medium", image}
+		args = []string{"docker", "scan", "--accept-license", "--severity", "medium", image}
 		fmt.Println(strings.Join(args, " "))
 		cmd = exec.Command(args[0], args[1:]...)
 		cmd.Stdout = os.Stdout


### PR DESCRIPTION
## Description
This PR will remove `-f <Dockerfile>` option from `docker scan`.

## Motivation and Context
This is causing errors in GitHub Actions. It should be added back after further researches.

## How Has This Been Tested?
I tested this by running `docker scan` as `after_publish` hook on my repo.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
