### PR TITLE
feat: add hooks for before and after version generation

### DIFF
--- a/cmd/winch/commands/ci.go
+++ b/cmd/winch/commands/ci.go
@@ -168,7 +168,7 @@ func ci(ctx context.Context) error {
 		}
 
 		fmt.Println("Creating version")
-		err = writeVersion(cfg, version, prerelease)
+		err = writeVersion(ctx, cfg, version, prerelease)
 		if err != nil {
 			return err
 		}
@@ -184,7 +184,7 @@ func ci(ctx context.Context) error {
 		prerelease = os.Getenv("BUILD_PRERELEASE")
 
 		fmt.Println("Creating version")
-		err = writeVersion(cfg, version, prerelease)
+		err = writeVersion(ctx, cfg, version, prerelease)
 		if err != nil {
 			return err
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -115,8 +115,10 @@ type Config struct {
 	Test          *RunConfig                   `json:"test,omitempty" yaml:"test,omitempty"`
 	AfterTest     *RunConfig                   `json:"after_test,omitempty" yaml:"after_test,omitempty"`
 	Changelog     *TemplateFileConfig          `json:"changelog,omitempty" yaml:"changelog,omitempty"`
+	BeforeVersion *RunConfig                   `json:"before_version,omitempty" yaml:"before_version,omitempty"`
 	Version       *TemplateFileConfig          `json:"version,omitempty" yaml:"version,omitempty"`
 	Versions      []*TemplateFileConfig        `json:"versions,omitempty" yaml:"versions,omitempty"`
+	AfterVersion  *RunConfig                   `json:"after_version,omitempty" yaml:"after_version,omitempty"`
 	GitHubAction  *TemplateFileConfig          `json:"githubaction,omitempty" yaml:"githubaction,omitempty"`
 	Dockerfile    *TemplateFileConfig          `json:"dockerfile,omitempty" yaml:"dockerfile,omitempty"`
 	Dockerfiles   []*TemplateFileConfig        `json:"dockerfiles,omitempty" yaml:"dockerfiles,omitempty"`
@@ -163,7 +165,7 @@ var (
 			Enabled: makeBool(false),
 		},
 		GitHubAction: &TemplateFileConfig{
-			Enabled:  makeBool(false),
+			Enabled: makeBool(false),
 		},
 		Homebrew: homebrew,
 	}


### PR DESCRIPTION
## Description
This PR adds `before_version` and `after_version` hooks to be executed before or after version generation.

## Motivation and Context
Sometimes you want to run command before/after version generation, such as updating `README`.

## How Has This Been Tested?
```bash
$ cat winch.yml
...
before_version:
  command: |
    echo "BEFORE!"
version:
  file: charts/transponder/Chart.yaml
after_version:
  command: |
    echo "AFTER!"
...
$ winch generate version
echo "BEFORE!"

BEFORE!
echo "AFTER!"

AFTER!
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
