### PR TITLE
feat: allow variable depth for monorepos

### DIFF
--- a/cmd/winch/commands/ci.go
+++ b/cmd/winch/commands/ci.go
@@ -75,7 +75,12 @@ func mono(ctx context.Context, cfg *config.Config, commits []*winch.Commit, dryR
 		}
 	}
 
-	files, err := filepath.Glob("*/winch.yml")
+	path := make([]string, cfg.MonoDepth+1)
+	for i := range path {
+		path[i] = "*"
+	}
+	path[len(path)-1] = "winch.yml"
+	files, err := filepath.Glob(filepath.Join(path...))
 	if err != nil {
 		return err
 	}

--- a/docker/helm/Dockerfile
+++ b/docker/helm/Dockerfile
@@ -2,10 +2,12 @@ FROM jnorwood/helm-docs:latest AS helm-docs
 
 FROM alpine:latest
 ENV DOCKER_CONFIG /etc/docker
-RUN apk add --update --no-cache curl docker git openssh-client zip
+RUN apk add --update --no-cache curl docker git openssh-client zip jq bash openssl yq
 RUN mkdir -p $DOCKER_CONFIG/cli-plugins && \
-    curl https://github.com/docker/scan-cli-plugin/releases/latest/download/docker-scan_linux_amd64 -L -s -S -o $DOCKER_CONFIG/cli-plugins/docker-scan && \
-    chmod +x $DOCKER_CONFIG/cli-plugins/docker-scan
+    curl -fsSL https://github.com/docker/scan-cli-plugin/releases/latest/download/docker-scan_linux_amd64 -o $DOCKER_CONFIG/cli-plugins/docker-scan && \
+    chmod +x $DOCKER_CONFIG/cli-plugins/docker-scan \
+RUN curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+RUN curl -fsSL https://install-cli.jfrog.io | sh
 COPY --from=helm-docs /usr/bin/helm-docs /usr/bin/helm-docs
 COPY bin/linux-amd64/winch /usr/local/bin/winch
 COPY docker/entrypoint.sh /entrypoint.sh

--- a/docker/helm/Dockerfile
+++ b/docker/helm/Dockerfile
@@ -5,7 +5,7 @@ ENV DOCKER_CONFIG /etc/docker
 RUN apk add --update --no-cache curl docker git openssh-client zip jq bash openssl yq
 RUN mkdir -p $DOCKER_CONFIG/cli-plugins && \
     curl -fsSL https://github.com/docker/scan-cli-plugin/releases/latest/download/docker-scan_linux_amd64 -o $DOCKER_CONFIG/cli-plugins/docker-scan && \
-    chmod +x $DOCKER_CONFIG/cli-plugins/docker-scan \
+    chmod +x $DOCKER_CONFIG/cli-plugins/docker-scan
 RUN curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 RUN curl -fsSL https://install-cli.jfrog.io | sh
 COPY --from=helm-docs /usr/bin/helm-docs /usr/bin/helm-docs

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -102,6 +102,7 @@ type Config struct {
 	Verbose       bool                         `json:"verbose,omitempty" yaml:"verbose,omitempty"`
 	Quiet         bool                         `json:"quiet,omitempty" yaml:"quiet,omitempty"`
 	Mono          bool                         `json:"mono,omitempty" yaml:"mono,omitempty"`
+	MonoDepth     int                          `json:"mono_depth,omitempty" yaml:"mono_depth,omitempty"`
 	Parallelism   int                          `json:"arallelism,omitempty" yaml:"parallelism,omitempty"`
 	Language      string                       `json:"language,omitempty" yaml:"language,omitempty"`
 	Toolchain     string                       `json:"toolchain,omitempty" yaml:"toolchain,omitempty"`
@@ -595,6 +596,11 @@ func LoadConfig(ctx context.Context) (context.Context, error) {
 	// Force git if a monorepo
 	if cfg.Mono {
 		cfg.Local = true
+	}
+
+	// A value less than 1 does not make sense here
+	if cfg.MonoDepth < 1 {
+		cfg.MonoDepth = 1
 	}
 
 	return AddConfigToContext(ctx, cfg), nil

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -26,6 +26,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -100,7 +101,12 @@ func (g Git) GetCommits(ctx context.Context) ([]*Commit, error) {
 
 			for _, stat := range stats {
 				if stat.Addition > 0 || stat.Deletion > 0 {
-					affectedPaths[strings.Split(stat.Name, "/")[0]] = true
+					path := strings.Split(stat.Name, "/")
+					depth := len(path)
+					if len(path) > cfg.MonoDepth {
+						depth = cfg.MonoDepth
+					}
+					affectedPaths[filepath.Join(path[0:depth]...)] = true
 				}
 			}
 		}


### PR DESCRIPTION
## Description
This PR adds `mono_depth` config. It allows users to configure the directory depth for monorepo set up. So that `winch.yml` can be placed multiple layers deep.

## How Has This Been Tested?
```shell
$ ls foo/bar
winch.yml
$ winch build -v
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
